### PR TITLE
fix(issue update): CRY-28 - Implement the pr command

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    linear-cli (0.7.5)
+    linear-cli (0.7.6)
       base64 (~> 0.2)
       dry-cli (~> 1.0)
       dry-cli-completion (~> 1.0)

--- a/exe/lc.sh
+++ b/exe/lc.sh
@@ -9,9 +9,10 @@ then
     linear-cli "$@" 2>&1|sed 's/linear-cli/lc/g'
     exit 0
 fi
-if ! linear-cli "$@"
-then
-    printf "lc: linear-cli failed\n" >&2
+linear-cli "$@"
+result=$?
+if [ $result -gt 1 ]; then
+    printf "lc: linear-cli failed %s\n" $result >&2
     lc "$@" --help 2>&1
     exit 1
 fi

--- a/lib/linear/cli/version.rb
+++ b/lib/linear/cli/version.rb
@@ -2,6 +2,6 @@
 
 module Rubyists
   module Linear
-    VERSION = '0.7.5'
+    VERSION = '0.7.6'
   end
 end

--- a/lib/linear/commands/issue.rb
+++ b/lib/linear/commands/issue.rb
@@ -4,6 +4,8 @@
 # as well as other helpers which are used in multiple commands and subcommands
 # This is also where the #prompt method is defined, which is used to display messages to the user and get input
 require_relative '../cli/sub_commands'
+require 'tty-editor'
+require 'git'
 
 module Rubyists
   module Linear
@@ -15,6 +17,7 @@ module Rubyists
         include CLI::SubCommands
 
         DESCRIPTION = 'Manage issues'
+        ALLOWED_PR_TYPES = 'bug|fix|sec(urity)|feat(ure)|chore|refactor|test|docs|style|ci|perf'
 
         # Aliases for Issue commands
         ALIASES = {
@@ -22,6 +25,7 @@ module Rubyists
           develop: %w[d dev],    # aliases for the develop command
           list: %w[l ls],        # aliases for the list command
           update: %w[u],         # aliases for the close command
+          pr: %w[pull-request],  # aliases for the pr command
           issue: %w[i issues]    # aliases for the main issue command itself
         }.freeze
 
@@ -49,11 +53,56 @@ module Rubyists
           prompt.ok "#{issue.identifier} was #{done}"
         end
 
+        def pr_type_for(issue)
+          proposed_type = issue.title.match(/^(#{ALLOWED_PR_TYPES})/i)
+          return proposed_type[1].downcase if proposed_type
+
+          prompt.select('What type of PR is this?', %w[fix feature chore refactor test docs style ci perf security])
+        end
+
+        def pr_scope_for(title)
+          proposed_scope = title.match(/^\w+\(([^\)]+)\)/)
+          return proposed_scope[1].downcase if proposed_scope
+
+          scope = prompt.ask('What is the scope of this PR?', default: 'none')
+          return nil if scope.empty? && scope == 'none'
+
+          scope
+        end
+
+        def pr_title_for(issue)
+          proposed = [pr_type_for(issue)]
+          proposed_scope = pr_scope_for(issue.title)
+          proposed << "(#{proposed_scope})" if proposed_scope
+          summary = issue.title.sub(/(?:#{ALLOWED_PR_TYPES})(\([^)]+\))? /, '')
+          proposed << ": #{issue.identifier} - #{summary}"
+          prompt.ask("Title for PR for #{issue.identifier} - #{summary}", default: proposed.join)
+        end
+
+        def pr_description_for(issue)
+          tmpfile = Tempfile.new([issue.identifier, '.md'], Rubyists::Linear.tmpdir)
+          # TODO: Look up templates
+          proposed = "# Context\n\n#{issue.description}\n\n## Issue\n\n#{issue.identifier}\n\n# Solution\n\n# Testing\n\n# Notes\n\n" # rubocop:disable Layout/LineLength
+          tmpfile.write(proposed) && tmpfile.close
+          desc = TTY::Editor.open(tmpfile.path)
+          return tmpfile if desc
+
+          File.open(tmpfile.path, 'w+') do |file|
+            file.puts prompt.ask("Description for PR for #{issue.identifier} - #{issue.title}", default: proposed)
+          end
+          tmpfile
+        end
+
+        def create_pr!(title:, body:)
+          return `gh pr create -a @me --title "#{title}" --body-file "#{body.path}"` if body.respond_to?(:path)
+
+          `gh pr create -a @me --title "#{title}" --body "#{body}"`
+        end
+
         def issue_pr(issue, **options)
           title = options[:title] || pr_title_for(issue)
           body = options[:description] || pr_description_for(issue)
-          issue.create_pr!(title:, body:)
-          prompt.ok "Pull request created for #{issue.identifier}"
+          create_pr!(title:, body:)
         end
 
         def update_issue(issue, **options)

--- a/lib/linear/commands/issue/pr.rb
+++ b/lib/linear/commands/issue/pr.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'semantic_logger'
+require 'git'
+require_relative '../issue'
+
+module Rubyists
+  # Namespace for Linear
+  module Linear
+    M :issue, :user, :label
+    # Namespace for CLI
+    module CLI
+      module Issue
+        Pr = Class.new Dry::CLI::Command
+        # The Develop class is a Dry::CLI::Command to start/update development status of an issue
+        class Pr
+          include SemanticLogger::Loggable
+          include Rubyists::Linear::CLI::CommonOptions
+          include Rubyists::Linear::CLI::Issue # for #gimme_da_issue! and other Issue methods
+          desc 'Create a PR for an issue and push it to the remote'
+          argument :issue_id, required: true, desc: 'The Issue (i.e. CRY-1)'
+          option :title, required: false, desc: 'The title of the PR'
+          option :description, required: false, desc: 'The description of the PR'
+
+          def call(issue_id:, **options)
+            logger.debug('Creating  PR for issue issue', options:)
+            issue = gimme_da_issue!(issue_id, me: Rubyists::Linear::User.me)
+            branch_name = issue.branchName
+            branch = branch_for(branch_name)
+            branch.checkout
+            prompt.ok "Checked out branch #{branch_name}"
+            issue_pr(issue, **options)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Context

The option to use the --pr option to the update command exists
but it has not yet been implemented. Fill in the gap.

## Issue

CRY-28

# Solution

Instead of adding on to the options for issue update, turned pr
into its own command 'issue pr ISSUE_ID'

# Testing

Tested only on the positive

# Notes

Needs more testing along the lines of if the local working tree is in good shape, on the
right branch, etc.
