### PR TITLE
fix: Fix WorkflowState bug

### DIFF
--- a/lib/linear/models/team.rb
+++ b/lib/linear/models/team.rb
@@ -6,6 +6,7 @@ module Rubyists
   # Namespace for Linear
   module Linear
     M :base_model
+    M :workflow_state
     Team = Class.new(BaseModel)
     # The Issue class represents a Linear issue.
     class Team


### PR DESCRIPTION
Declare WorkflowState in team.rb to avoid uninitialized `Rubyists::Linear::Team::WorkflowState` error.